### PR TITLE
Fix testCI fails.

### DIFF
--- a/src/transform_ast.jl
+++ b/src/transform_ast.jl
@@ -131,11 +131,13 @@ function stochastic_indexing(expr::Expr)
     return MacroTools.postwalk(expr) do sub_expr
         if @capture(sub_expr, v_[idxs__])
             is_stochastic_var = (in(all_stochastic_lhs)).(idxs)
-            new_idxs = deepcopy(idxs)
-            new_idxs[is_stochastic_var] .= :(:)
-            sub_expr = Expr(
-                :call, :_getindex, Expr(:ref, v, new_idxs...), idxs...
-            )
+            if any(is_stochastic_var)
+                new_idxs = deepcopy(idxs)
+                new_idxs[is_stochastic_var] .= :(:)
+                sub_expr = Expr(
+                    :call, :_getindex, Expr(:ref, v, new_idxs...), idxs...
+                )
+            end
         end
         return sub_expr
     end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -204,7 +204,6 @@ ex = @bugsast begin
     end
 end
 
-@register_function foo(x::Array) = sum(x)
 @register_function foobar(x::Array) = sum(x)
 @register_distribution bar(v::Array) = SymbolicPPL.dcat(reduce(vcat, v))
 


### PR DESCRIPTION
* Found a bug in `transform_ast.jl`: in `stochastic_indexing` function, now the rewrite from `ref` to `_getindex` only happens when there are stochastic variables.